### PR TITLE
Add environment variables to config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ pip-log.txt
 .mr.developer.cfg
 venv
 .idea/
-
 MANIFEST
-
+.pytest_cache/
 nosetests.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
 ## Not Released
+- [2018-08-19] allow environment variables in the yaml configuration data `foo: <%= ENV['env_variable'] %>`
 - [2018-08-05] conditional reader / writer
 - [2018-08-05] moved deploy call to `Engine.run`

--- a/drupan/tests/test_config.py
+++ b/drupan/tests/test_config.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 import unittest
 
 from drupan.config import Config
@@ -59,6 +60,19 @@ class TestConfig(unittest.TestCase):
         self.config.redirects = {"foo": "bar"}
         redirects = self.config.get_option(None, "redirects")
         self.assertEqual(type(redirects), dict)
+
+    def test_env_loader(self):
+        os.environ["drupan_test_foo"] = "bar"
+
+        yaml = """options:
+          bar:
+            foo: <%= ENV['drupan_test_foo'] %>
+        """
+        self.config.parse_yaml(yaml)
+
+        del os.environ["drupan_test_foo"]
+
+        self.assertEqual(self.config.get_option("bar", "foo"), "bar")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add environment variable tag to YAML parser - this allows putting sensitive variables, such as AWS access and secret keys in environment variables instead of checking them into the config.

This will help automating site deployments through a CI.